### PR TITLE
Support const name methods

### DIFF
--- a/lib/yadriggy/ast.rb
+++ b/lib/yadriggy/ast.rb
@@ -300,11 +300,11 @@ module Yadriggy
     end
 
     # @param [Array] s  an S-expression.
-    # @param [Symbol] tag
+    # @param [Array<Symbol>] tags
     # @return [Array] the S-expression if it starts with the tag.
     #   Otherwise, raise an error.
-    def has_tag?(s, tag)
-      raise "s-exp is not :#{tag.to_s}. #{s}" if !s.nil? && s[0] != tag
+    def has_tag?(s, *tags)
+      raise "s-exp is not :#{tags.join(", ")}. #{s}" if !s.nil? && !tags.include?(s[0])
       s
     end
   end
@@ -916,7 +916,7 @@ module Yadriggy
       @name = if sexp[3] == :call
                 nil
               else
-                @name = to_node(has_tag?(sexp[3], :@ident))
+                @name = to_node(has_tag?(sexp[3], :@ident, :@const))
               end
       add_child(@receiver)
       add_child(@name)
@@ -1596,7 +1596,7 @@ module Yadriggy
       @name = if def_name[0] == :@op
                 to_node(def_name)
               else
-                to_node(has_tag?(def_name, :@ident))
+                to_node(has_tag?(def_name, :@ident, :@const))
               end
       add_child(@name)
 

--- a/lib/yadriggy/syntax.rb
+++ b/lib/yadriggy/syntax.rb
@@ -514,7 +514,7 @@ module Yadriggy
                        block_param: (Identifier) }
         Block      <= Parameters + { body: exprs }
         Lambda     <= Block
-        Call       <= { receiver: (expr), op: (Symbol), name: (Identifier),
+        Call       <= { receiver: (expr), op: (Symbol), name: (Identifier | Const),
                         args: [ expr ], block_arg: (expr), block: (Block) }
         Command    <= Call
         Exprs      <= { expressions: [ expr ] }
@@ -524,7 +524,7 @@ module Yadriggy
                         else: (exprs), ensure: (exprs) }
         BeginEnd   <= { body: exprs, rescue: (Rescue) }
         Def        <= Parameters +
-                      { singular: (expr), name: Identifier, body: exprs,
+                      { singular: (expr), name: (Identifier | Const), body: exprs,
                         rescue: (Rescue) }
         ModuleDef  <= { name: Const | ConstPathRef, body: exprs,
                         rescue: (Rescue) }

--- a/lib/yadriggy/type.rb
+++ b/lib/yadriggy/type.rb
@@ -621,7 +621,7 @@ module Yadriggy
     # Obtains the name of this type.
     # @return [String] the type name.
     def name
-      name = @ruby_class.name
+      name = @ruby_class.name.dup
       name << '<' << @args.map{|e| e.name }.join(',') << '>'
       name
     end

--- a/test/yadriggy/ast_test2.rb
+++ b/test/yadriggy/ast_test2.rb
@@ -20,6 +20,10 @@ module Yadriggy
     i
   end
 
+  def self.ConstNameMethod(i)
+    i
+  end
+
   @@check_ast_const_path = Yadriggy.reify do |e|
     YadAstCheck::A = 3
     ::YadAstCheck000 = 7
@@ -479,6 +483,9 @@ module Yadriggy
     proc.call(@@check_ast_const_path)
     proc.call(@@check_ast_module)
     proc.call(@@check_ast_class)
+
+    code = -> { ConstNameMethod(1) }
+    proc.call(Yadriggy.reify(code))
 
     # pp Yadriggy.reify(code)
 


### PR DESCRIPTION
@chibash I'd like to support defining and calling methods whose names begin with upper case letters.  This is necessary to accept the uses of core methods such as `Kernel.Integer` and `Kernel.Float`.