### PR TITLE
Support CompositeType in Type.get_instance_method_object

### DIFF
--- a/lib/yadriggy/type.rb
+++ b/lib/yadriggy/type.rb
@@ -627,6 +627,17 @@ module Yadriggy
       name << '<' << @args.map{|e| e.name }.join(',') << '>'
       name
     end
+
+    # @api private
+    # Gets a method with the given name declared in this type.
+    # `nil` is returned when the method is not exactly determined.
+    #
+    # @return [Method|nil]
+    def get_method_object(method_name)
+      exact_type.instance_method(method_name)
+    rescue NameError
+      Type.error_found!("no such method: #{@ruby_class}\##{method_name}")
+    end
   end
 
   # A role that can be attached to a {Type} object.

--- a/test/yadriggy/type_test.rb
+++ b/test/yadriggy/type_test.rb
@@ -285,5 +285,20 @@ module Yadriggy
 
     end
 
+    test 'Type.get_instance_method_object' do
+      assert_equal(nil, Type.get_instance_method_object(DynType, :to_s))
+
+      assert_equal(String.instance_method(:length), Type.get_instance_method_object(RubyClass::String, :length))
+
+      assert_raise(TypeChecker::CheckError) do
+        Type.get_instance_method_object(RubyClass::Symbol, :to_f)
+      end
+
+      ct = CompositeType.new(Array, [Integer])
+      assert_equal(Array.instance_method(:shuffle), Type.get_instance_method_object(ct, :shuffle))
+
+      ct2 = CompositeType.new(Range, [Integer])
+      assert_equal(Range.instance_method(:each), Type.get_instance_method_object(ct2, :each))
+    end
   end
 end


### PR DESCRIPTION
I'd like to support `CompositeType` in `Type.get_instance_method_object`.  This enables to infer composite types such as `Array` and `Range`.
